### PR TITLE
fix the compilation error when building on Windows using VS2013

### DIFF
--- a/tests/auto/allocatortest.cpp
+++ b/tests/auto/allocatortest.cpp
@@ -41,25 +41,25 @@ void AllocatorTest::testAllocationParams()
     p->setPadding(30ul);
 
     QCOMPARE(p->flags(), QGst::MemoryFlagReadonly | QGst::MemoryFlagNotMappable);
-    QCOMPARE(p->align(), 10ul);
-    QCOMPARE(p->prefix(), 20ul);
-    QCOMPARE(p->padding(), 30ul);
+    QCOMPARE(p->align(), static_cast<size_t>(10));
+    QCOMPARE(p->prefix(), static_cast<size_t>(20));
+    QCOMPARE(p->padding(), static_cast<size_t>(30));
 
     // Does copy work?
     QGst::AllocationParams c(*p);
 
     QCOMPARE(c.flags(), QGst::MemoryFlagReadonly | QGst::MemoryFlagNotMappable);
-    QCOMPARE(c.align(), 10ul);
-    QCOMPARE(c.prefix(), 20ul);
-    QCOMPARE(c.padding(), 30ul);
+    QCOMPARE(c.align(), static_cast<size_t>(10));
+    QCOMPARE(c.prefix(), static_cast<size_t>(20));
+    QCOMPARE(c.padding(), static_cast<size_t>(30));
 
     // Does copy really work. (delete the source)
     delete p;
 
     QCOMPARE(c.flags(), QGst::MemoryFlagReadonly | QGst::MemoryFlagNotMappable);
-    QCOMPARE(c.align(), 10ul);
-    QCOMPARE(c.prefix(), 20ul);
-    QCOMPARE(c.padding(), 30ul);
+    QCOMPARE(c.align(), static_cast<size_t>(10));
+    QCOMPARE(c.prefix(), static_cast<size_t>(20));
+    QCOMPARE(c.padding(), static_cast<size_t>(30));
 }
 
 void AllocatorTest::testAllocator()

--- a/tests/auto/discoverertest.cpp
+++ b/tests/auto/discoverertest.cpp
@@ -15,8 +15,10 @@
     You should have received a copy of the GNU Lesser General Public License
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 #include "qgsttest.h"
 
+#include <functional>
 #include <QGlib/Connect>
 #include <QGlib/Error>
 


### PR DESCRIPTION
1. when building qt-gstreamer on  windows using VS2013, following error will be reported
 "error C2039: 'bind2nd' : is not a member of 'std'"
'"error C2039: 'mem_fun' : is not a member of 'std'"
The fix is to add "#include <functional>" to resolve this compilation error. 
Please refer to http://stackoverflow.com/questions/24580416/mem-fun-is-not-a-member-of-std

2. QCOMPARE is very strict on the data types. Both actual and expected have to be of the same type, otherwise the test won't compile. When build on window with VS2013, size_t will be interpreted as "_uint64", which is different from "unsigned long".

The fix is to static_cast all constant number to "size_t"


